### PR TITLE
Update publication pagination style (add years)

### DIFF
--- a/layouts/section/publication.html
+++ b/layouts/section/publication.html
@@ -9,9 +9,11 @@
   </div>
   <div class="row">
     <div class="col col-8 offset-2">
-      <ul class="publications-list">
         
-        {{ range .Paginator.Pages.ByDate.Reverse }} 
+      {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }} 
+      <h2 class="publications-year">{{ .Key }}</h2>
+      <ul class="publications-list">
+        {{ range .Pages }}
         <li itemscope itemtype="http://schema.org/CreativeWork">
           <a href="{{ .Permalink }}" itemprop="headline" class="large">{{ .Title }}</a>
           {{ if .Description }}
@@ -21,8 +23,9 @@
           {{ end }}
         </li> 
         {{ end }}
-        <section>{{ partial "pagination" .}}</section>
       </ul>
+      {{ end }}
+        <section>{{ partial "pagination" .}}</section>
     </div>
   </div>
 </div>

--- a/layouts/section/publication.html
+++ b/layouts/section/publication.html
@@ -10,7 +10,7 @@
   <div class="row">
     <div class="col col-8 offset-2">
         
-      {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }} 
+      {{ range (.Paginate (.Pages.GroupByDate "2006") 10).PageGroups }} 
       <h2 class="publications-year">{{ .Key }}</h2>
       <ul class="publications-list">
         {{ range .Pages }}


### PR DESCRIPTION
I guess this is what a PR on a PR looks like!

This is the easy version: inserting headers with year into the list.

The pagination is still by number of publications (and the current site default is 5 per page), so the page breaks occur every ~5~ 10 pubs regardless of year.

Poking around the internet I think anything more complicated than this is going to be ... complicated.

Edited: updated pagination to 10 pubs/page