### PR TITLE
fix links to shinydag

### DIFF
--- a/content/project/shinydag.Rmd
+++ b/content/project/shinydag.Rmd
@@ -13,10 +13,10 @@ callout: |
   effects.
   
 header_buttons:
-  - text: "Run Demo App"
-    url: "https://apps.gerkelab.com/shinyDAG/"
-    icon: "fas fa-rocket"
-    class: "primary"
+  # - text: "Run Demo App"
+  #   url: "https://apps.gerkelab.com/shinyDAG/"
+  #   icon: "fas fa-rocket"
+  #   class: "primary"
   - text: "View Source on GitHub"
     url: "https://github.com/GerkeLab/ShinyDAG"
     icon: "fab fa-github"

--- a/content/project/shinydag.Rmd
+++ b/content/project/shinydag.Rmd
@@ -22,7 +22,7 @@ header_buttons:
     icon: "fab fa-github"
     class: "secondary"
   - text: "Docker Hub"
-    url: "https://hub.docker.com/r/gerkelab/shinydagd"
+    url: "https://hub.docker.com/r/gerkelab/shinydag"
     icon: "fab fa-docker"
     class: "info"
 ---

--- a/content/project/shinydag.html
+++ b/content/project/shinydag.html
@@ -13,10 +13,10 @@ callout: |
   effects.
   
 header_buttons:
-  - text: "Run Demo App"
-    url: "https://apps.gerkelab.com/shinyDAG/"
-    icon: "fas fa-rocket"
-    class: "primary"
+  # - text: "Run Demo App"
+  #   url: "https://apps.gerkelab.com/shinyDAG/"
+  #   icon: "fas fa-rocket"
+  #   class: "primary"
   - text: "View Source on GitHub"
     url: "https://github.com/GerkeLab/ShinyDAG"
     icon: "fab fa-github"

--- a/content/project/shinydag.html
+++ b/content/project/shinydag.html
@@ -22,7 +22,7 @@ header_buttons:
     icon: "fab fa-github"
     class: "secondary"
   - text: "Docker Hub"
-    url: "https://hub.docker.com/r/gerkelab/shinydagd"
+    url: "https://hub.docker.com/r/gerkelab/shinydag"
     icon: "fab fa-docker"
     class: "info"
 ---


### PR DESCRIPTION
Very minor fix to correct links to ShinyDAG...

...but @tgerke can you do the upgrade things to get netlify working again?


> UNSUPPORTED BUILD IMAGE
> 
> The build image for this site uses Ubuntu 14.04 Trusty Tahr, which is no longer supported.
> 
> To enable builds for this site, select a later build image at the following link:
> https://app.netlify.com/sites/gerkelab/settings/deploys#build-image-selection
> 
> For more details, visit the build image migration guide:
> https://answers.netlify.com/t/end-of-support-for-trusty-build-image-everything-you-need-to-know/39004